### PR TITLE
Fix version file syntax

### DIFF
--- a/GameData/kOS-Career/kos-career.version
+++ b/GameData/kOS-Career/kos-career.version
@@ -2,11 +2,10 @@
 	"NAME":"kOS-Career",
 	"URL":"https://raw.githubusercontent.com/JonnyOThan/kOS-Career/master/GameData/kos-career.version",
 	"DOWNLOAD":"https://github.com/JonnyOThan/KOS-career/releases",
-	"GITHUB":
-	{
+	"GITHUB":{
 		"USERNAME":"JonnyOThan",
 		"REPOSITORY":"kOS-Career",
-		"ALLOW_PRE_RELEASE":false,
+		"ALLOW_PRE_RELEASE":false
 	},
 	"VERSION":{
 		"MAJOR":0,
@@ -23,7 +22,7 @@
 		"MAJOR":1,
 		"MINOR":8,
 		"PATCH":0
-	}
+	},
 	"KSP_VERSION_MAX":{
 		"MAJOR":1,
 		"MINOR":10,


### PR DESCRIPTION
```
Running NetKAN for NetKAN/kOS-Career.netkan
3636 [1] WARN CKAN.NetKAN.Validators.VrefValidator (null) - Error parsing version file GameData/kOS-Career/kos-career.version: After parsing a value an unexpected character was encountered: ". Path 'KSP_VERSION_MIN', line 27, position 1.
3660 [1] FATAL CKAN.NetKAN.Program (null) - Error parsing version file GameData/kOS-Career/kos-career.version: After parsing a value an unexpected character was encountered: ". Path 'KSP_VERSION_MIN', line 27, position 1.
Build step 'Execute shell' marked build as failure
```

There's a missing comma and an extra comma. Now fixed.

Discovered during review of KSP-CKAN/NetKAN#8151.

Shout-out to @DasSkelett's GitHub Action for validating these:

- https://github.com/DasSkelett/AVC-VersionFileValidator