### PR TITLE
Add SET parameter state suffixes to contracts.

### DIFF
--- a/kOS-Career/Contract.cs
+++ b/kOS-Career/Contract.cs
@@ -2,6 +2,8 @@
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Utilities;
+using kOS.Suffixed;
+using Steamworks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,9 +50,14 @@ namespace kOS.AddOns.kOSCareer
 			AddSuffix("ACCEPT", new NoArgsVoidSuffix(Accept));
 			AddSuffix("DECLINE", new NoArgsVoidSuffix(Decline));
 			AddSuffix("CANCEL", new NoArgsVoidSuffix(Cancel));
-		}
 
-		private ListValue<KOSContractParameter> GetParameters()
+            AddSuffix("COMPLETE", new OneArgsSuffix<StringValue>(Complete, "Completes the Parameter"));
+            AddSuffix("INCOMPLETE", new OneArgsSuffix<StringValue>(Incomplete, "Resets the Parameter"));
+            AddSuffix("FAIL", new OneArgsSuffix<StringValue>(Fail, "Fails the Parameter"));
+
+        }
+
+        private ListValue<KOSContractParameter> GetParameters()
 		{
 			var result = new ListValue<KOSContractParameter>();
 
@@ -79,9 +86,55 @@ namespace kOS.AddOns.kOSCareer
 			if (m_contract.ContractState != Contracts.Contract.State.Offered) throw new KOSException("Contract cannot be accepted");
 			m_contract.Accept();
 		}
-	}
 
-	[KOSNomenclature("ContractParameter")]
+        private void SetParameter(String action, String parameterTitle)
+        {
+            foreach (var parameter in m_contract.AllParameters)
+            {
+                if (parameter.Title == parameterTitle && parameter.Title.StartsWith("KOS"))
+                {
+                    switch (action)
+                    {
+                        case "COMPLETE":
+                            if (parameter.state.ToString() != "Complete")
+                            {
+                                parameter.SetComplete();
+                            }
+                            break;
+                        case "INCOMPLETE":
+                            if (parameter.state.ToString() != "Incomplete")
+                            {
+                                parameter.SetIncomplete();
+                            }
+                            break;
+                        case "FAIL":
+                            if (parameter.state.ToString() != "Failed")
+                            {
+                                parameter.SetFailed();
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+        private void Complete(StringValue parameterTitle)
+        {
+            SetParameter("COMPLETE", parameterTitle);
+        }
+
+        private void Incomplete(StringValue parameterTitle)
+        {
+            SetParameter("INCOMPLETE", parameterTitle);
+        }
+
+        private void Fail(StringValue parameterTitle)
+        {
+            SetParameter("FAIL", parameterTitle);
+        }
+    }
+
+
+    [KOSNomenclature("ContractParameter")]
 	class KOSContractParameter : kOS.Safe.Encapsulation.Structure
 	{
 		Contracts.ContractParameter m_parameter;
@@ -103,7 +156,7 @@ namespace kOS.AddOns.kOSCareer
 			AddSuffix("TITLE", new Suffix<StringValue>(() => m_parameter.Title));
 			AddSuffix("NOTES", new Suffix<StringValue>(() => m_parameter.Notes));
 			AddSuffix("PARAMETERS", new Suffix<ListValue<KOSContractParameter>>(GetParameters));
-		}
+        }
 
 		private ListValue<KOSContractParameter> GetParameters()
 		{
@@ -116,5 +169,5 @@ namespace kOS.AddOns.kOSCareer
 
 			return result;
 		}
-	}
+    }
 }


### PR DESCRIPTION
Anti-cheat measure included (contract parameters must be written with KOS control allowed).  
If you wish to remove the anti-cheat, you can remove ` && parameter.Title.StartsWith("KOS")`

Testing:

1. Accept a contract with the following parameter:
```
PARAMETER { name = KOS_test
		type = AtLeast
		count = 99
		title = KOS_Testing
	}
```
2. Run KerboScript:
```
clearScreen.
FOR contract IN ADDONS:CAREER:ACTIVECONTRACTS() {
    print contract:title().
    FOR parameter IN contract:PARAMETERS {
        //print parameter.
        IF parameter:title:contains("KOS") {
            print parameter:title.
            print parameter:state.
            wait 1.
            contract:complete("KOS_Testing").
            wait 1.
            print parameter:state.
        }
    }
}
```


https://github.com/user-attachments/assets/534a84db-7b81-4e44-a3c8-52e480d12521

