### PR TITLE
Add CHEAT_SET_STATE and ID suffix to contract parameters.

### DIFF
--- a/kOS-Career/Contract.cs
+++ b/kOS-Career/Contract.cs
@@ -103,6 +103,28 @@ namespace kOS.AddOns.kOSCareer
 			AddSuffix("TITLE", new Suffix<StringValue>(() => m_parameter.Title));
 			AddSuffix("NOTES", new Suffix<StringValue>(() => m_parameter.Notes));
 			AddSuffix("PARAMETERS", new Suffix<ListValue<KOSContractParameter>>(GetParameters));
+
+			AddSuffix("ID", new Suffix<StringValue>(() => m_parameter.ID));
+			AddSuffix("CHEAT_SET_STATE", new OneArgsSuffix<StringValue>(SetState, "Sets the parameter state (COMPLETE|INCOMPLETE|FAIL)"));
+		}
+
+		private void SetState(StringValue action)
+		{
+			switch (action)
+			{
+				case "COMPLETE":
+					if (m_parameter.State.ToString() == "Completed") throw new KOSException("Parameter cannot set to Complete");
+					m_parameter.SetComplete();
+					break;
+				case "INCOMPLETE":
+					if (m_parameter.State.ToString() == "Incomplete") throw new KOSException("Parameter cannot be set to Incomplete");
+					m_parameter.SetIncomplete();
+					break;
+				case "FAIL":
+					if (m_parameter.State.ToString() == "Failed") throw new KOSException("Parameter cannot be set to Failed");
+					m_parameter.SetFailed();
+					break;
+			}
 		}
 
 		private ListValue<KOSContractParameter> GetParameters()

--- a/kOS-Career/Contract.cs
+++ b/kOS-Career/Contract.cs
@@ -105,25 +105,17 @@ namespace kOS.AddOns.kOSCareer
 			AddSuffix("PARAMETERS", new Suffix<ListValue<KOSContractParameter>>(GetParameters));
 
 			AddSuffix("ID", new Suffix<StringValue>(() => m_parameter.ID));
-			AddSuffix("CHEAT_SET_STATE", new OneArgsSuffix<StringValue>(SetState, "Sets the parameter state (COMPLETE|INCOMPLETE|FAIL)"));
+			AddSuffix("CHEAT_SET_STATE", new OneArgsSuffix<StringValue>(SetState, "Sets the parameter state (COMPLETE|INCOMPLETE|FAILED)"));
 		}
 
 		private void SetState(StringValue action)
 		{
-			switch (action)
+  			var newState = action.ToString().ToEnum<Contracts.ParameterState>();
+  			switch (newState)
 			{
-				case "COMPLETE":
-					if (m_parameter.State.ToString() == "Completed") throw new KOSException("Parameter cannot set to Complete");
-					m_parameter.SetComplete();
-					break;
-				case "INCOMPLETE":
-					if (m_parameter.State.ToString() == "Incomplete") throw new KOSException("Parameter cannot be set to Incomplete");
-					m_parameter.SetIncomplete();
-					break;
-				case "FAIL":
-					if (m_parameter.State.ToString() == "Failed") throw new KOSException("Parameter cannot be set to Failed");
-					m_parameter.SetFailed();
-					break;
+				case Contracts.ParameterState.Incomplete: m_parameter.SetIncomplete(); break;			
+				case Contracts.ParameterState.Complete:   m_parameter.SetComplete(); break;
+				case Contracts.ParameterState.Failed:     m_parameter.SetFailed(); break;
 			}
 		}
 


### PR DESCRIPTION
New suffix **CHEAT_SET_STATE** will allow players to set the state of any contract parameter.  The argument for this suffix can be COMPLETE, INCOMPLETE, or FAIL.
Also adds **ID** suffix to contract parameters which represents the parameter `Name` so players can identify unique and hidden contract parameters instead of by `Title` which can produce duplicates and will not show hidden parameters.

```
SET ALL TO ADDONS:CAREER:ACTIVECONTRACTS()[0]:PARAMETERS().
FOR P IN ALL {
    IF P:ID = "Parameter_Name" {
        print "Current State = " + p:STATE.
        P:CHEAT_SET_STATE("COMPLETE").
        wait 0.2.
        print "New State = " + P:STATE.
    }
}
```